### PR TITLE
Sspm 259/puppet telegraf module logrotate windows

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,15 @@
 # [*logfile*]
 #   String. Path to the log file.
 #
+# [*logfile_rotation_interval*]
+#   String. The time interval for which the logfile will be rotated
+#   0 specifies no rotation
+# [*$logfile_rotation_max_size*]
+#   String. The size at which point the log file will be rotated
+#   0 specifies no file size rotation
+# [*logfile_rotation_max_archives*]
+#   Interger. The minimum amount of log file archives to retain
+#   -1 specifies no archives for removal
 # [*config_file_owner*]
 #   String. User to own the telegraf config file.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class telegraf (
   validate_string($logfile)
   validate_string($logfile_rotation_interval)
   validate_string($logfile_rotation_max_size)
-  validate_string($logfile_rotation_max_archives)
+  validate_integer($logfile_rotation_max_archives)
   validate_string($config_file_owner)
   validate_string($config_file_group)
   validate_absolute_path($config_folder)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class telegraf (
   validate_string($logfile)
   validate_string($logfile_rotation_interval)
   validate_string($logfile_rotation_max_size)
-  validate_integer($logfile_rotation_max_archives)
+  validate_float($logfile_rotation_max_archives)
   validate_string($config_file_owner)
   validate_string($config_file_group)
   validate_absolute_path($config_folder)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,10 +19,10 @@
 #
 # [*logfile_rotation_interval*]
 #   String. The time interval for which the logfile will be rotated
-#   0 specifies no rotation
+#   0d specifies no time based rotation
 # [*$logfile_rotation_max_size*]
 #   String. The size at which point the log file will be rotated
-#   0 specifies no file size rotation
+#   0MB specifies no file size rotation
 # [*logfile_rotation_max_archives*]
 #   Interger. The minimum amount of log file archives to retain
 #   -1 specifies no archives for removal

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class telegraf (
   validate_string($logfile)
   validate_string($logfile_rotation_interval)
   validate_string($logfile_rotation_max_size)
-  validate_float($logfile_rotation_max_archives)
+  validate_integer($logfile_rotation_max_archives)
   validate_string($config_file_owner)
   validate_string($config_file_group)
   validate_absolute_path($config_folder)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,36 +87,39 @@
 #   String.  URL for windows telegraf chocolatey repo
 #
 class telegraf (
-  $package_name           = $telegraf::params::package_name,
-  $ensure                 = $telegraf::params::ensure,
-  $config_file            = $telegraf::params::config_file,
-  $config_file_owner      = $telegraf::params::config_file_owner,
-  $config_file_group      = $telegraf::params::config_file_group,
-  $config_folder          = $telegraf::params::config_folder,
-  $hostname               = $telegraf::params::hostname,
-  $omit_hostname          = $telegraf::params::omit_hostname,
-  $interval               = $telegraf::params::interval,
-  $round_interval         = $telegraf::params::round_interval,
-  $metric_batch_size      = $telegraf::params::metric_batch_size,
-  $metric_buffer_limit    = $telegraf::params::metric_buffer_limit,
-  $collection_jitter      = $telegraf::params::collection_jitter,
-  $flush_interval         = $telegraf::params::flush_interval,
-  $flush_jitter           = $telegraf::params::flush_jitter,
-  $logfile                = $telegraf::params::logfile,
-  $debug                  = $telegraf::params::debug,
-  $quiet                  = $telegraf::params::quiet,
-  $inputs                 = $telegraf::params::inputs,
-  $outputs                = $telegraf::params::outputs,
-  $global_tags            = $telegraf::params::global_tags,
-  $manage_service         = $telegraf::params::manage_service,
-  $manage_repo            = $telegraf::params::manage_repo,
-  $purge_config_fragments = $telegraf::params::purge_config_fragments,
-  $repo_type              = $telegraf::params::repo_type,
-  $windows_package_url    = $telegraf::params::windows_package_url,
-  $service_enable         = $telegraf::params::service_enable,
-  $service_ensure         = $telegraf::params::service_ensure,
-  $service_restart        = $telegraf::params::service_restart,
-  $install_options        = $telegraf::params::install_options,
+  $package_name                  = $telegraf::params::package_name,
+  $ensure                        = $telegraf::params::ensure,
+  $config_file                   = $telegraf::params::config_file,
+  $config_file_owner             = $telegraf::params::config_file_owner,
+  $config_file_group             = $telegraf::params::config_file_group,
+  $config_folder                 = $telegraf::params::config_folder,
+  $hostname                      = $telegraf::params::hostname,
+  $omit_hostname                 = $telegraf::params::omit_hostname,
+  $interval                      = $telegraf::params::interval,
+  $round_interval                = $telegraf::params::round_interval,
+  $metric_batch_size             = $telegraf::params::metric_batch_size,
+  $metric_buffer_limit           = $telegraf::params::metric_buffer_limit,
+  $collection_jitter             = $telegraf::params::collection_jitter,
+  $flush_interval                = $telegraf::params::flush_interval,
+  $flush_jitter                  = $telegraf::params::flush_jitter,
+  $logfile                       = $telegraf::params::logfile,
+  $logfile_rotation_interval     = $telegraf::params::logfile_rotation_interval,
+  $logfile_rotation_max_size     = $telegraf::params::logfile_rotation_max_size,
+  $logfile_rotation_max_archives = $telegraf::params::logfile_rotation_max_archives,
+  $debug                         = $telegraf::params::debug,
+  $quiet                         = $telegraf::params::quiet,
+  $inputs                        = $telegraf::params::inputs,
+  $outputs                       = $telegraf::params::outputs,
+  $global_tags                   = $telegraf::params::global_tags,
+  $manage_service                = $telegraf::params::manage_service,
+  $manage_repo                   = $telegraf::params::manage_repo,
+  $purge_config_fragments        = $telegraf::params::purge_config_fragments,
+  $repo_type                     = $telegraf::params::repo_type,
+  $windows_package_url           = $telegraf::params::windows_package_url,
+  $service_enable                = $telegraf::params::service_enable,
+  $service_ensure                = $telegraf::params::service_ensure,
+  $service_restart               = $telegraf::params::service_restart,
+  $install_options               = $telegraf::params::install_options,
 ) inherits ::telegraf::params
 {
 
@@ -126,6 +129,9 @@ class telegraf (
   validate_string($ensure)
   validate_string($config_file)
   validate_string($logfile)
+  validate_string($logfile_rotation_interval)
+  validate_string($logfile_rotation_max_size)
+  validate_string($logfile_rotation_max_archives)
   validate_string($config_file_owner)
   validate_string($config_file_group)
   validate_absolute_path($config_folder)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class telegraf::params {
     $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
     $logfile_rotation_interval     = '0d'
     $logfile_rotation_max_size     = '0MB'
-    $logfile_rotation_max_archives = -1
+    $logfile_rotation_max_archives = '-1'
     $manage_repo                   = false
     $service_enable                = true
     $service_ensure                = running

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,9 @@ class telegraf::params {
     $config_file_group             = 'Administrators'
     $config_folder                 = 'C:/Program Files/telegraf/telegraf.d'
     $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
-    $logfile_rotation_interval     = "0d"
-    $logfile_rotation_max_size     = "0MB"
-    $logfile_rotation_max_archives = "-1"
+    $logfile_rotation_interval     = '0d'
+    $logfile_rotation_max_size     = '0MB'
+    $logfile_rotation_max_archives = '-1'
     $manage_repo                   = false
     $service_enable                = true
     $service_ensure                = running

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,65 +1,35 @@
-# == Class: telegraf::params
-#
-# A set of default parameters for Telegraf's configuration.
-#
-class telegraf::params {
+class profile::telegraf (
+){
+  contain '::telegraf'
 
-  if $::osfamily == 'windows' {
-    $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
-    $config_file_owner    = 'Administrator'
-    $config_file_group    = 'Administrators'
-    $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
-    $logfile              = 'C:/Program Files/telegraf/telegraf.log'
-    $manage_repo          = false
-    $service_enable       = true
-    $service_ensure       = running
-    $service_hasstatus    = false
-    $service_restart      = undef
-  } else {
-    $config_file          = '/etc/telegraf/telegraf.conf'
-    $config_file_owner    = 'telegraf'
-    $config_file_group    = 'telegraf'
-    $config_folder        = '/etc/telegraf/telegraf.d'
-    $logfile              = ''
-    $manage_repo          = true
-    $service_enable       = true
-    $service_ensure       = running
-    $service_hasstatus    = true
-    $service_restart      = 'pkill -HUP telegraf'
-  }
-  $package_name           = 'telegraf'
-  $ensure                 = 'present'
-  $install_options        = []
-  $hostname               = $::hostname
-  $omit_hostname          = false
-  $interval               = '10s'
-  $round_interval         = true
-  $metric_batch_size      = '1000'
-  $metric_buffer_limit    = '10000'
-  $collection_jitter      = '0s'
-  $flush_interval         = '10s'
-  $flush_jitter           = '0s'
-  $debug                  = false
-  $quiet                  = false
-  $global_tags            = {}
-  $manage_service         = true
-  $purge_config_fragments = false
-  $repo_type              = 'stable'
-  $windows_package_url    = 'https://chocolatey.org/api/v2/'
+  $inputs = hiera_hash('profile::telegraf::inputs',{})
+  create_resources(telegraf::input, $inputs)
 
-  $outputs = {
-    'influxdb'  => {
-      'urls'     => [ 'http://localhost:8086' ],
-      'database' => 'telegraf',
-      'username' => 'telegraf',
-      'password' => 'metricsmetricsmetrics',
+  $redis_inputs = hiera('profile::telegraf::redis::inputs',{})
+  $redis_inputs_defaults = hiera('profile::telegraf::redis::inputs::defaults',{})
+  create_resources(telegraf::input, $redis_inputs,$redis_inputs_defaults)
+
+  $outputs = hiera_hash('profile::telegraf::outputs',{})
+  create_resources(telegraf::output, $outputs)
+
+  $consul_services = hiera_hash('profile::telegraf::consul_services', {})
+  $consul_checks = hiera_hash('profile::telegraf::consul_checks', {})
+
+  case $::kernel {
+    'Linux':   {
+      create_resources('::consul::service', $consul_services)
+      create_resources('::consul::check', $consul_checks)
+      user { "telegraf":
+        groups => ["puppet","root"],
+        notify => Class['telegraf::service'],
+      }
     }
+    'windows': {
+      create_resources('::winconsul::service', $consul_services)
+      create_resources('::winconsul::check', $consul_checks)
+    }
+    default:   { fail("Unknown kernel ${::kernel}") }
   }
 
-  $inputs = {
-    'cpu'  => {
-      'percpu'   => true,
-      'totalcpu' => true,
-    }
-  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class telegraf::params {
     $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
     $logfile_rotation_interval     = '0d'
     $logfile_rotation_max_size     = '0MB'
-    $logfile_rotation_max_archives = '5'
+    $logfile_rotation_max_archives = '-1'
     $manage_repo                   = false
     $service_enable                = true
     $service_ensure                = running

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,6 @@ class telegraf::params {
     $config_file_group             = 'Administrators'
     $config_folder                 = 'C:/Program Files/telegraf/telegraf.d'
     $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
-    $logfile_rotation_interval     = '0d'
-    $logfile_rotation_max_size     = '0MB'
-    $logfile_rotation_max_archives = '-1'
     $manage_repo                   = false
     $service_enable                = true
     $service_ensure                = running
@@ -49,6 +46,9 @@ class telegraf::params {
   $purge_config_fragments = false
   $repo_type              = 'stable'
   $windows_package_url    = 'https://chocolatey.org/api/v2/'
+  $logfile_rotation_interval     = '0d'
+  $logfile_rotation_max_size     = '0MB'
+  $logfile_rotation_max_archives = '-1'
 
   $outputs = {
     'influxdb'  => {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,16 +5,19 @@
 class telegraf::params {
 
   if $::osfamily == 'windows' {
-    $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
-    $config_file_owner    = 'Administrator'
-    $config_file_group    = 'Administrators'
-    $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
-    $logfile              = 'C:/Program Files/telegraf/telegraf.log'
-    $manage_repo          = false
-    $service_enable       = true
-    $service_ensure       = running
-    $service_hasstatus    = false
-    $service_restart      = undef
+    $config_file                   = 'C:/Program Files/telegraf/telegraf.conf'
+    $config_file_owner             = 'Administrator'
+    $config_file_group             = 'Administrators'
+    $config_folder                 = 'C:/Program Files/telegraf/telegraf.d'
+    $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
+    $logfile_rotation_interval     = "0d"
+    $logfile_rotation_max_size     = "0MB"
+    $logfile_rotation_max_archives = "-1"
+    $manage_repo                   = false
+    $service_enable                = true
+    $service_ensure                = running
+    $service_hasstatus             = false
+    $service_restart               = undef
   } else {
     $config_file          = '/etc/telegraf/telegraf.conf'
     $config_file_owner    = 'telegraf'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class telegraf::params {
     $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
     $logfile_rotation_interval     = '0d'
     $logfile_rotation_max_size     = '0MB'
-    $logfile_rotation_max_archives = '-1'
+    $logfile_rotation_max_archives = -1
     $manage_repo                   = false
     $service_enable                = true
     $service_ensure                = running

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class telegraf::params {
     $logfile                       = 'C:/Program Files/telegraf/telegraf.log'
     $logfile_rotation_interval     = '0d'
     $logfile_rotation_max_size     = '0MB'
-    $logfile_rotation_max_archives = '-1'
+    $logfile_rotation_max_archives = '5'
     $manage_repo                   = false
     $service_enable                = true
     $service_ensure                = running

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -20,9 +20,9 @@
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"
   logfile = "<%= @logfile %>"
-  logfile_rotation_interval = "<% @logfile_rotation_interval %>"
-  logfile_rotation_max_size = "<% @logfile_rotation_max_size  %>"
-  logfile_rotation_max_archives = "<% @logfile_rotation_max_archives %>"
+  logfile_rotation_interval = "<%= @logfile_rotation_interval %>"
+  logfile_rotation_max_size = "<%= @logfile_rotation_max_size  %>"
+  logfile_rotation_max_archives = "<%= @logfile_rotation_max_archives %>"
   debug = <%= @debug %>
   quiet = <%= @quiet %>
 

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -20,9 +20,9 @@
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"
   logfile = "<%= @logfile %>"
-  logfile_rotation_interval = "<% =@logfile_rotation_interval %>"
-  logfile_rotation_max_size = "<% =@logfile_rotation_max_size  %>"
-  logfile_rotation_max_archives = "<% =@logfile_rotation_max_archives %>"
+  logfile_rotation_interval = "<% @logfile_rotation_interval %>"
+  logfile_rotation_max_size = "<% @logfile_rotation_max_size  %>"
+  logfile_rotation_max_archives = "<% @logfile_rotation_max_archives %>"
   debug = <%= @debug %>
   quiet = <%= @quiet %>
 

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -22,7 +22,7 @@
   logfile = "<%= @logfile %>"
   logfile_rotation_interval = "<%= @logfile_rotation_interval %>"
   logfile_rotation_max_size = "<%= @logfile_rotation_max_size  %>"
-  logfile_rotation_max_archives = "<%= @logfile_rotation_max_archives %>"
+  logfile_rotation_max_archives = <%= @logfile_rotation_max_archives %>
   debug = <%= @debug %>
   quiet = <%= @quiet %>
 

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -20,6 +20,9 @@
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"
   logfile = "<%= @logfile %>"
+  logfile_rotation_interval = "<% =@logfile_rotation_interval %>"
+  logfile_rotation_max_size = "<% =@logfile_rotation_max_size  %>"
+  logfile_rotation_max_archives = "<% =@logfile_rotation_max_archives %>"
   debug = <%= @debug %>
   quiet = <%= @quiet %>
 


### PR DESCRIPTION
https://bedegaming.atlassian.net/browse/SSPM-249

Added support to the telegraph puppet module to support log rotation on windows systems, the defaults will not change what is in place at present however we can override these were needed. As part of the Azure metrics work we need to rotate files as logs can be aggressive and quickly build up.

The log config works for both windows and linux, so have made a slight change. As mentioned above this will not change current behaviour just allows us to apply rotation to the config should we need to 

Link to Telegraf config doc:https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md
<img width="413" alt="Screenshot 2020-04-24 at 18 33 47" src="https://user-images.githubusercontent.com/14092056/80240813-681b0000-865a-11ea-9034-3c2e9da95f48.png">
<img width="555" alt="Screenshot 2020-04-24 at 18 33 13" src="https://user-images.githubusercontent.com/14092056/80240823-6b15f080-865a-11ea-8555-d71088801a96.png">
